### PR TITLE
Fix the path to the jQuery folder in gruntfile.js

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
 					dest: "src/public/vendor/bootswatch/"
 				}, {
 					expand: true,
-					cwd: "bower_components/jquery/",
+					cwd: "bower_components/jquery/dist/",
 					src: ["jquery.js"],
 					dest: "src/public/vendor/"
 				}, {


### PR DESCRIPTION
The jquery.js folder is `bower_components/jquery/dist/`. It gave errors on the page because the file wasn't found on server start and the page wasn't working.